### PR TITLE
docs(fix): add the sequencer crypto library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The best place to follow along is the KZG Ceremony channel in the Ethereum R&D D
 
 ## Client Implementations
 
-- [KZG sequencer crypto library](https://github.com/ethereum/kzg-ceremony-sequencer/tree/master/crypto) (Rust)
+- [KZG sequencer crypto wrapper](https://github.com/zkparty/wrapper-small-pot) (Rust)
 - [Small powers of Tau](https://github.com/crate-crypto/small-powers-of-tau) (Rust)
 - [Worldcoin](https://github.com/worldcoin/kzg-ceremony-client) (client - WIP)
   - [WASM contribution code](https://github.com/worldcoin/kzg-ceremony-participant) (Rust)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The best place to follow along is the KZG Ceremony channel in the Ethereum R&D D
 
 ## Client Implementations
 
+- [KZG sequencer crypto library](https://github.com/ethereum/kzg-ceremony-sequencer/tree/master/crypto) (Rust)
 - [Small powers of Tau](https://github.com/crate-crypto/small-powers-of-tau) (Rust)
 - [Worldcoin](https://github.com/worldcoin/kzg-ceremony-client) (client - WIP)
   - [WASM contribution code](https://github.com/worldcoin/kzg-ceremony-participant) (Rust)


### PR DESCRIPTION
The sequencer code has a separate crypto library that could be used as a client implementation. We are doing that in [https://github.com/zkparty/trusted-setup-frontend](https://github.com/zkparty/trusted-setup-frontend).

It would be great to point this out in this repository so people can use it to build different implementations. I am even thinking on adding the [https://github.com/zkparty/trusted-setup-frontend](https://github.com/zkparty/trusted-setup-frontend) so people can based on it to build different web applications (although it would use the same client implementation as the sequencer).